### PR TITLE
Reuse single osu API client instance

### DIFF
--- a/src/lib/osuApi.ts
+++ b/src/lib/osuApi.ts
@@ -3,11 +3,6 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-declare global {
-  // eslint-disable-next-line no-var
-  var __omc_osu_api_instance: Promise<osu.API> | undefined;
-}
-
 const resolveCredentials = () => {
   const rawClientId = process.env.OSU_CLIENT_ID;
   const clientSecret = process.env.OSU_CLIENT_SECRET;
@@ -33,10 +28,18 @@ const createApiInstance = async (): Promise<osu.API> => {
   return osu.API.createAsync(clientId, clientSecret);
 };
 
-const apiPromise: Promise<osu.API> = globalThis.__omc_osu_api_instance ?? (
-  globalThis.__omc_osu_api_instance = createApiInstance()
-);
+class OsuApi {
+  private static instance: Promise<osu.API> | null = null;
 
-export const getApi = (): Promise<osu.API> => apiPromise;
+  static getInstance(): Promise<osu.API> {
+    if (!OsuApi.instance) {
+      OsuApi.instance = createApiInstance();
+    }
 
-export const api: osu.API = await apiPromise;
+    return OsuApi.instance;
+  }
+}
+
+export const getApi = (): Promise<osu.API> => OsuApi.getInstance();
+
+export const api: osu.API = await OsuApi.getInstance();

--- a/src/lib/osuApi.ts
+++ b/src/lib/osuApi.ts
@@ -1,39 +1,42 @@
 import * as osu from "osu-api-v2-js";
-
 import dotenv from "dotenv";
+
 dotenv.config();
 
-class ApiWrapper {
-  private static instance: osu.API | null = null;
-  private static initPromise: Promise<osu.API> | null = null;
-
-  private static async initialize(): Promise<osu.API> {
-    if (this.instance) {
-      return this.instance;
-    }
-
-    if (this.initPromise) {
-      return this.initPromise;
-    }
-
-    this.initPromise = (async () => {
-      const clientId = Number(process.env.OSU_CLIENT_ID);
-      const clientSecret = process.env.OSU_CLIENT_SECRET;
-
-      if (!clientSecret) {
-        throw new Error("OSU_CLIENT_SECRET not configured");
-      }
-
-      this.instance = await osu.API.createAsync(clientId, clientSecret);
-      return this.instance;
-    })();
-
-    return this.initPromise;
-  }
-
-  static async getApi(): Promise<osu.API> {
-    return this.initialize();
-  }
+declare global {
+  // eslint-disable-next-line no-var
+  var __omc_osu_api_instance: Promise<osu.API> | undefined;
 }
 
-export const api = await ApiWrapper.getApi();
+const resolveCredentials = () => {
+  const rawClientId = process.env.OSU_CLIENT_ID;
+  const clientSecret = process.env.OSU_CLIENT_SECRET;
+
+  if (!rawClientId) {
+    throw new Error("OSU_CLIENT_ID not configured");
+  }
+  if (!clientSecret) {
+    throw new Error("OSU_CLIENT_SECRET not configured");
+  }
+
+  const clientId = Number.parseInt(rawClientId, 10);
+
+  if (Number.isNaN(clientId)) {
+    throw new Error("OSU_CLIENT_ID must be a valid number");
+  }
+
+  return { clientId, clientSecret };
+};
+
+const createApiInstance = async (): Promise<osu.API> => {
+  const { clientId, clientSecret } = resolveCredentials();
+  return osu.API.createAsync(clientId, clientSecret);
+};
+
+const apiPromise: Promise<osu.API> = globalThis.__omc_osu_api_instance ?? (
+  globalThis.__omc_osu_api_instance = createApiInstance()
+);
+
+export const getApi = (): Promise<osu.API> => apiPromise;
+
+export const api: osu.API = await apiPromise;


### PR DESCRIPTION
- cache a shared osu API instance on globalThis so consumers reuse the same stateful client
- validate OAuth credentials before instantiation for clearer failures
- keep both async getter and awaited export for compatibility with existing imports
