### PR TITLE
Disallow Seishun no Archive

### DIFF
--- a/data/overrides/edge-cases.json
+++ b/data/overrides/edge-cases.json
@@ -9,5 +9,11 @@
     "artist": "Lusumi",
     "resultOverride": "disallowed",
     "failureReasonOverride": "disallowedByRightsholder"
+  },
+  {
+    "title": "Seishun no Archive",
+    "artist": "Abydos High School Foreclosure Task Force",
+    "resultOverride": "disallowed",
+    "failureReasonOverride": "disallowedByRightsholder"
   }
 ]


### PR DESCRIPTION
Adds `Seishun no Archive - Abydos High School Foreclosure Task Force` to edge case overrides.

before:

```json
{
    "results": [
        {
            "beatmapIds": [
                4563307
            ],
            "beatmapsetId": 2163686,
            "complianceStatus": 0,
            "complianceStatusString": "OK",
            "cover": "https://assets.ppy.sh/beatmaps/2163686/covers/cover.jpg?1715157050",
            "artist": "Abydos High School Foreclosure Task Force",
            "title": "Seishun no Archive (TV Size)",
            "ownerId": 19901680,
            "ownerUsername": "ler1211",
            "status": "graveyard"
        }
    ],
    "failures": []
}
```

after:

```json
{
    "results": [
        {
            "beatmapIds": [
                4563307
            ],
            "beatmapsetId": 2163686,
            "complianceStatus": 2,
            "complianceStatusString": "DISALLOWED",
            "cover": "https://assets.ppy.sh/beatmaps/2163686/covers/cover.jpg?1715157050",
            "artist": "Abydos High School Foreclosure Task Force",
            "title": "Seishun no Archive (TV Size)",
            "ownerId": 19901680,
            "ownerUsername": "ler1211",
            "status": "graveyard",
            "complianceFailureReason": 3,
            "complianceFailureReasonString": "DISALLOWED_BY_RIGHTSHOLDER",
            "notes": "The rightsholder has prohibited use of this track."
        }
    ],
    "failures": []
}
```